### PR TITLE
feat: added settings to be removed in version 6.0

### DIFF
--- a/django_removals/checks/settings.py
+++ b/django_removals/checks/settings.py
@@ -82,6 +82,9 @@ REMOVED_SETTINGS = {
     "6.0": {
         "FORMS_URLFIELD_ASSUME_HTTPS",
     },
+    "7.0": {
+        "URLIZE_ASSUME_HTTPS",
+    },
 }
 
 

--- a/django_removals/checks/settings.py
+++ b/django_removals/checks/settings.py
@@ -79,6 +79,9 @@ REMOVED_SETTINGS = {
         "DEFAULT_FILE_STORAGE",
         "STATICFILES_STORAGE",
     },
+    "6.0": {
+        "FORMS_URLFIELD_ASSUME_HTTPS",
+    },
 }
 
 


### PR DESCRIPTION
Added the setting to be removed in Django 6.0 to the settings.py

https://docs.djangoproject.com/en/dev/releases/6.0/#deprecated-features-6-0