### PR TITLE
Add Django 6.1 settings deprecations (v1.2.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**1.2.0** (2026-05-27)
+  * Added known settings deprecations from Django 6.1: the `EMAIL_*` settings (replaced by `MAILERS`) and `USE_BLANK_CHOICE_DASH`
+
 **1.1.8** (2026-03-30)
   * Maintenance updates via ambient-package-update
 

--- a/django_removals/__init__.py
+++ b/django_removals/__init__.py
@@ -1,3 +1,3 @@
 """Tool for finding removed features in your Django project"""
 
-__version__ = "1.1.8"
+__version__ = "1.2.0"

--- a/django_removals/checks/settings.py
+++ b/django_removals/checks/settings.py
@@ -84,6 +84,20 @@ REMOVED_SETTINGS = {
     },
     "7.0": {
         "URLIZE_ASSUME_HTTPS",
+        # Email settings deprecated in 6.1 in favour of the "MAILERS" setting
+        "EMAIL_BACKEND",
+        "EMAIL_FILE_PATH",
+        "EMAIL_HOST",
+        "EMAIL_HOST_PASSWORD",
+        "EMAIL_HOST_USER",
+        "EMAIL_PORT",
+        "EMAIL_USE_TLS",
+        "EMAIL_USE_SSL",
+        "EMAIL_SSL_CERTFILE",
+        "EMAIL_SSL_KEYFILE",
+        "EMAIL_TIMEOUT",
+        # Transitional setting deprecated in 6.1
+        "USE_BLANK_CHOICE_DASH",
     },
 }
 

--- a/tests/checks/test_settings.py
+++ b/tests/checks/test_settings.py
@@ -54,6 +54,22 @@ class RemovedSettingsCheckTests(SimpleTestCase):
             all_issues,
         )
 
+    @override_settings(EMAIL_HOST="smtp.example.com")
+    @mock.patch.object(django, "VERSION", new=(7, 0, 0))
+    def test_check_removed_settings_django_61_email_deprecation(self, *args):
+        all_issues = checks.run_checks(tags=None)
+
+        self.assertIn(
+            checks.Warning(
+                "The 'EMAIL_HOST' setting was removed in Django 7.0 and its use is not recommended.",
+                hint="Please refer to the documentation: https://docs.djangoproject.com/en/stable/releases/"
+                "7.0/#features-removed-in-7-0.",
+                obj="EMAIL_HOST",
+                id="removals.W070/email_host",
+            ),
+            all_issues,
+        )
+
     @override_settings(LOGOUT_URL="/logout")
     def test_non_float_django_versions(self, *args):
         all_issues = checks.run_checks(tags=None)


### PR DESCRIPTION
Add the settings deprecated in Django 6.1 to the removal checks: the EMAIL_* settings (replaced by the new MAILERS config) and the transitional USE_BLANK_CHOICE_DASH setting. They are keyed to their 7.0 removal version so the check stays silent until a project runs Django 7.0.