### PR TITLE
Fix incorrect setting removal versions and version comparison (v1.2.1)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+**1.2.1** (2026-05-27)
+  * Fixed incorrect removal versions for several settings: `DATABASE_*` / `TEST_DATABASE_*` (1.2 → 1.4),
+    `TRANSACTIONS_MANAGED` (1.4 → 1.8), `AUTH_PROFILE_MODULE` (1.5 → 1.7), the legacy `TEST_*` database
+    settings (1.7 → 1.8) and `PASSWORD_RESET_TIMEOUT_DAYS` (3.0 → 4.0)
+  * Fixed version comparison so double-digit minor versions (e.g. Django 1.10) are evaluated correctly
+
 **1.2.0** (2026-05-27)
   * Added known settings deprecations from Django 6.1: the `EMAIL_*` settings (replaced by `MAILERS`) and `USE_BLANK_CHOICE_DASH`
 

--- a/django_removals/__init__.py
+++ b/django_removals/__init__.py
@@ -1,3 +1,3 @@
 """Tool for finding removed features in your Django project"""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/django_removals/checks/settings.py
+++ b/django_removals/checks/settings.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core.checks import Warning  # noqa: A004
 
 REMOVED_SETTINGS = {
-    "1.2": {
+    "1.4": {
         "DATABASE_ENGINE",
         "DATABASE_HOST",
         "DATABASE_NAME",
@@ -15,13 +15,8 @@ REMOVED_SETTINGS = {
         "TEST_DATABASE_COLLATION",
         "TEST_DATABASE_NAME",
     },
-    "1.4": {
-        "TRANSACTIONS_MANAGED",
-    },
-    "1.5": {
-        "AUTH_PROFILE_MODULE",
-    },
     "1.7": {
+        "AUTH_PROFILE_MODULE",
         "SOUTH_DATABASE_ADAPTER",
         "SOUTH_DATABASE_ADAPTERS",
         "SOUTH_AUTO_FREEZE_APP",
@@ -30,6 +25,11 @@ REMOVED_SETTINGS = {
         "SOUTH_LOGGING_FILE",
         "SOUTH_MIGRATION_MODULES",
         "SOUTH_USE_PYC",
+    },
+    "1.8": {
+        "SEND_BROKEN_LINK_EMAILS",
+        "CACHE_MIDDLEWARE_ANONYMOUS_ONLY",
+        "TRANSACTIONS_MANAGED",
         "TEST_CREATE",
         "TEST_USER_CREATE",
         "TEST_PASSWD",
@@ -39,10 +39,6 @@ REMOVED_SETTINGS = {
         "TEST_DATABASE_PASSWORD",
         "TEST_DATABASE_PORT",
         "TEST_DATABASE_USER",
-    },
-    "1.8": {
-        "SEND_BROKEN_LINK_EMAILS",
-        "CACHE_MIDDLEWARE_ANONYMOUS_ONLY",
     },
     "1.10": {
         "ALLOWED_INCLUDE_ROOTS",
@@ -61,7 +57,6 @@ REMOVED_SETTINGS = {
     },
     "3.0": {
         "DEFAULT_CONTENT_TYPE",
-        "PASSWORD_RESET_TIMEOUT_DAYS",
     },
     "3.1": {
         "FILE_CHARSET",
@@ -69,6 +64,7 @@ REMOVED_SETTINGS = {
     "4.0": {
         "DEFAULT_HASHING_ALGORITHM",
         "SECURE_BROWSER_XSS_FILTER",
+        "PASSWORD_RESET_TIMEOUT_DAYS",
     },
     "5.0": {
         "USE_L10N",
@@ -112,8 +108,10 @@ def check_removed_settings(**kwargs):
     for setting_name in dir(settings):
         # Iterate all known removals...
         for django_version, removed_settings in REMOVED_SETTINGS.items():
+            # Compare as (major, minor) tuples so multi-digit parts like "1.10" sort correctly...
+            removal_version = tuple(int(part) for part in django_version.split("."))
             # If our installed Django version is older than the upcoming removals, we ignore them...
-            if float(django_version) > django.VERSION[0] + django.VERSION[1] / 10:
+            if removal_version > django.VERSION[:2]:
                 continue
             # Check if we have a match...
             if setting_name.isupper() and setting_name in removed_settings:

--- a/tests/checks/test_settings.py
+++ b/tests/checks/test_settings.py
@@ -14,26 +14,26 @@ class RemovedSettingsCheckTests(SimpleTestCase):
 
         self.assertIn(
             checks.Warning(
-                "The 'TRANSACTIONS_MANAGED' setting was removed in Django 1.4 and its use is not recommended.",
+                "The 'TRANSACTIONS_MANAGED' setting was removed in Django 1.8 and its use is not recommended.",
                 hint="Please refer to the documentation: https://docs.djangoproject.com/en/stable/releases/"
-                "1.4/#features-removed-in-1-4.",
+                "1.8/#features-removed-in-1-8.",
                 obj="TRANSACTIONS_MANAGED",
-                id="removals.W014/transactions_managed",
+                id="removals.W018/transactions_managed",
             ),
             all_issues,
         )
 
-    @override_settings(SILENCED_SYSTEM_CHECKS=("removals.W014/transactions_managed",))
+    @override_settings(SILENCED_SYSTEM_CHECKS=("removals.W018/transactions_managed",))
     def test_ignoring_specific_warning_works(self):
         all_issues = checks.run_checks(tags=None)
 
         self.assertNotIn(
             checks.Warning(
-                "The 'TRANSACTIONS_MANAGED' setting was removed in Django 1.4 and its use is not recommended.",
+                "The 'TRANSACTIONS_MANAGED' setting was removed in Django 1.8 and its use is not recommended.",
                 hint="Please refer to the documentation: https://docs.djangoproject.com/en/stable/releases/"
-                "1.4/#features-removed-in-1-4.",
+                "1.8/#features-removed-in-1-8.",
                 obj="TRANSACTIONS_MANAGED",
-                id="removals.W014/transactions_managed",
+                id="removals.W018/transactions_managed",
             ),
             all_issues,
         )
@@ -66,6 +66,24 @@ class RemovedSettingsCheckTests(SimpleTestCase):
                 "7.0/#features-removed-in-7-0.",
                 obj="EMAIL_HOST",
                 id="removals.W070/email_host",
+            ),
+            all_issues,
+        )
+
+    @override_settings(LOGOUT_URL="/logout")
+    @mock.patch.object(django, "VERSION", new=(1, 9, 0))
+    def test_double_digit_minor_not_flagged_on_older_django(self, *args):
+        # "1.10" must compare as (1, 10), i.e. newer than the installed (1, 9),
+        # so the removal is not flagged. A naive float() would read it as 1.1.
+        all_issues = checks.run_checks(tags=None)
+
+        self.assertNotIn(
+            checks.Warning(
+                "The 'LOGOUT_URL' setting was removed in Django 1.10 and its use is not recommended.",
+                hint="Please refer to the documentation: https://docs.djangoproject.com/en/stable/releases/"
+                "1.10/#features-removed-in-1-10.",
+                obj="LOGOUT_URL",
+                id="removals.W0110/logout_url",
             ),
             all_issues,
         )


### PR DESCRIPTION
Several settings were keyed by their deprecation version rather than the version in which Django actually removed them:

  * DATABASE_* / TEST_DATABASE_* : 1.2 -> 1.4
  * TRANSACTIONS_MANAGED         : 1.4 -> 1.8
  * AUTH_PROFILE_MODULE          : 1.5 -> 1.7
  * legacy TEST_* db settings    : 1.7 -> 1.8
  * PASSWORD_RESET_TIMEOUT_DAYS  : 3.0 -> 4.0

Also fix the installed-version gate, which compared versions as floats and mis-parsed double-digit minor versions ("1.10" read as 1.1). It now compares (major, minor) tuples against django.VERSION[:2].