### PR TITLE
Add SIGNED_COOKIE_LEGACY_SALT_FALLBACK to settings removed in 7.0 (#18)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**1.4.0** (2026-07-09)
+  * Added `SIGNED_COOKIE_LEGACY_SALT_FALLBACK` to the settings removed in Django 7.0 (#18)
+
 **1.3.1** (2026-07-03)
   * Updated company and maintainer information to "Beyonder Deutschland"
 

--- a/django_removals/__init__.py
+++ b/django_removals/__init__.py
@@ -1,3 +1,3 @@
 """Tool for finding removed features in your Django project"""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/django_removals/checks/settings.py
+++ b/django_removals/checks/settings.py
@@ -94,6 +94,8 @@ REMOVED_SETTINGS = {
         "EMAIL_TIMEOUT",
         # Transitional setting deprecated in 6.1
         "USE_BLANK_CHOICE_DASH",
+        # Transitional setting introduced in the 5.2.15 security release, deprecated in 6.1
+        "SIGNED_COOKIE_LEGACY_SALT_FALLBACK",
     },
 }
 

--- a/tests/checks/test_settings.py
+++ b/tests/checks/test_settings.py
@@ -70,6 +70,23 @@ class RemovedSettingsCheckTests(SimpleTestCase):
             all_issues,
         )
 
+    @override_settings(SIGNED_COOKIE_LEGACY_SALT_FALLBACK=True)
+    @mock.patch.object(django, "VERSION", new=(7, 0, 0))
+    def test_check_removed_settings_signed_cookie_legacy_salt_fallback(self, *args):
+        all_issues = checks.run_checks(tags=None)
+
+        self.assertIn(
+            checks.Warning(
+                "The 'SIGNED_COOKIE_LEGACY_SALT_FALLBACK' setting was removed in Django 7.0 and its use is not "
+                "recommended.",
+                hint="Please refer to the documentation: https://docs.djangoproject.com/en/stable/releases/"
+                "7.0/#features-removed-in-7-0.",
+                obj="SIGNED_COOKIE_LEGACY_SALT_FALLBACK",
+                id="removals.W070/signed_cookie_legacy_salt_fallback",
+            ),
+            all_issues,
+        )
+
     @override_settings(LOGOUT_URL="/logout")
     @mock.patch.object(django, "VERSION", new=(1, 9, 0))
     def test_double_digit_minor_not_flagged_on_older_django(self, *args):


### PR DESCRIPTION
This transitional setting was introduced in the 5.2.15 security release and deprecated in Django 6.1, scheduled for removal in 7.0.

## Description

Please include a summary of the change and which issue is fixed (if any).

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project (linting passes)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation where necessary
- [ ] I have added an entry to `CHANGES.md`
- [ ] I have bumped the version in `django_removals/__init__.py`
